### PR TITLE
add options to the post requests

### DIFF
--- a/src/main/java/edu/kit/ipd/crowdcontrol/workerservice/Router.java
+++ b/src/main/java/edu/kit/ipd/crowdcontrol/workerservice/Router.java
@@ -109,6 +109,10 @@ public class Router implements SparkApplication, RequestHelper {
         });
 
         post("/calibrations/:workerID", concurrentUnwrap(commands::submitCalibration));
+        options("/calibrations/:workerID", (request, response) -> {
+            response.status(200);
+            return "";
+        });
 
     }
 


### PR DESCRIPTION
tl;dr browsers are doing options calls to request the accessability of a
rest resource

if you send a xhr most browsers will send a options request before, to
  see if the resource is available, we need to set there the 200 state
  so the resource is "available" if we dont do that 400 will be returned
  and no final post call to the resource is performed.

  ref: http://stackoverflow.com/questions/1256593/why-am-i-getting-an-options-request-instead-of-a-get-request